### PR TITLE
coco, imgnet lmdb updates data r/w

### DIFF
--- a/openselfsup/datasets/data_sources/imagenet_lmdb.py
+++ b/openselfsup/datasets/data_sources/imagenet_lmdb.py
@@ -7,14 +7,15 @@ import pyarrow as pa
 
 import torch.utils.data as data
 from ..registry import DATASOURCES
+import pickle
 
 
-def loads_pyarrow(buf):
+def loads_data(buf):
     """
     Args:
         buf: the output of `dumps`.
     """
-    return pa.deserialize(buf)
+    return pickle.loads(buf)
 
 
 @DATASOURCES.register_module
@@ -36,8 +37,8 @@ class ImageNetLMDB(data.Dataset):
                              readonly=True, lock=False,
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
-            self.length = loads_pyarrow(txn.get(b'__len__'))
-            self.keys = loads_pyarrow(txn.get(b'__keys__'))
+            self.length = loads_data(txn.get(b'__len__'))
+            self.keys = loads_data(txn.get(b'__keys__'))
 
     def __getitem__(self, index):
         # Delay loading LMDB data until after initialization: https://github.com/chainer/chainermn/issues/129
@@ -47,7 +48,7 @@ class ImageNetLMDB(data.Dataset):
         env = self.env
         with env.begin(write=False) as txn:
             byteflow = txn.get(self.keys[index])
-        unpacked = loads_pyarrow(byteflow)
+        unpacked = loads_data(byteflow)
 
         # load img.
         imgbuf = unpacked[0]

--- a/tools/folder2lmdb_imagenet.py
+++ b/tools/folder2lmdb_imagenet.py
@@ -8,10 +8,10 @@ import six
 import lmdb
 import pyarrow as pa
 import numpy as np
-
 import torch.utils.data as data
 from torch.utils.data import DataLoader
 from torchvision.datasets import ImageFolder
+import pickle
 
 
 def is_valid_file(filename):
@@ -27,12 +27,12 @@ def is_valid_file(filename):
     return flag
 
 
-def loads_pyarrow(buf):
+def loads_data(buf):
     """
     Args:
         buf: the output of `dumps`.
     """
-    return pa.deserialize(buf)
+    return pickle.loads(buf)
 
 
 class ImageFolderLMDB(data.Dataset):
@@ -42,8 +42,8 @@ class ImageFolderLMDB(data.Dataset):
                              readonly=True, lock=False,
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
-            self.length = loads_pyarrow(txn.get(b'__len__'))
-            self.keys = loads_pyarrow(txn.get(b'__keys__'))
+            self.length = loads_data(txn.get(b'__len__'))
+            self.keys = loads_data(txn.get(b'__keys__'))
 
         self.transform = transform
         self.target_transform = target_transform
@@ -53,7 +53,7 @@ class ImageFolderLMDB(data.Dataset):
         with env.begin(write=False) as txn:
             byteflow = txn.get(self.keys[index])
 
-        unpacked = loads_pyarrow(byteflow)
+        unpacked = loads_data(byteflow)
 
         # load img
         imgbuf = unpacked[0]
@@ -89,13 +89,13 @@ def raw_reader(path):
     return bin_data
 
 
-def dumps_pyarrow(obj):
+def dumps_data(obj):
     """
     Serialize an object.
     Returns:
         Implementation-dependent bytes-like object
     """
-    return pa.serialize(obj).to_buffer()
+    return pickle.dumps(obj)
 
 
 def folder2lmdb(dpath, name="train", workers=32, write_frequency=5000):
@@ -116,7 +116,7 @@ def folder2lmdb(dpath, name="train", workers=32, write_frequency=5000):
     for idx, data in enumerate(data_loader):
         image, label = data[0]
 
-        txn.put(u'{}'.format(idx).encode('ascii'), dumps_pyarrow((image, label)))
+        txn.put(u'{}'.format(idx).encode('ascii'), dumps_data((image, label)))
         if idx % write_frequency == 0:
             print("[%d/%d]" % (idx, len(data_loader)))
             txn.commit()
@@ -126,8 +126,8 @@ def folder2lmdb(dpath, name="train", workers=32, write_frequency=5000):
     txn.commit()
     keys = [u'{}'.format(k).encode('ascii') for k in range(idx + 1)]
     with db.begin(write=True) as txn:
-        txn.put(b'__keys__', dumps_pyarrow(keys))
-        txn.put(b'__len__', dumps_pyarrow(len(keys)))
+        txn.put(b'__keys__', dumps_data(keys))
+        txn.put(b'__len__', dumps_data(len(keys)))
 
     print("Flushing database ...")
     db.sync()


### PR DESCRIPTION
When building lmdb for efficiency in training pre-train models, the previous code has been deprecated. Update the code for compatibility with the latest PyTorch version.